### PR TITLE
Issue27016 raise value error: Fix failing pytest

### DIFF
--- a/sklearn/ensemble/tests/test_stacking.py
+++ b/sklearn/ensemble/tests/test_stacking.py
@@ -430,7 +430,10 @@ def test_stacking_classifier_stratify_default():
                 final_estimator=LogisticRegression(),
                 cv=KFold(shuffle=True, random_state=42),
             ),
-            *load_breast_cancer(return_X_y=True),
+            *[
+                scale(data) if idx == 0 else data
+                for idx, data in list(enumerate(load_breast_cancer(return_X_y=True)))
+            ],
         ),
         (
             StackingRegressor(
@@ -497,7 +500,10 @@ def test_stacking_classifier_sample_weight_fit_param():
                 ],
                 final_estimator=LogisticRegression(),
             ),
-            *load_breast_cancer(return_X_y=True),
+            *[
+                scale(data) if idx == 0 else data
+                for idx, data in list(enumerate(load_breast_cancer(return_X_y=True)))
+            ],
         ),
         (
             StackingRegressor(

--- a/sklearn/ensemble/tests/test_stacking.py
+++ b/sklearn/ensemble/tests/test_stacking.py
@@ -462,18 +462,15 @@ def test_stacking_with_sample_weight(stacker, X, y):
         X, y, total_sample_weight, random_state=42
     )
 
-    with ignore_warnings(category=ConvergenceWarning):
-        stacker.fit(X_train, y_train)
+    stacker.fit(X_train, y_train)
     y_pred_no_weight = stacker.predict(X_test)
 
-    with ignore_warnings(category=ConvergenceWarning):
-        stacker.fit(X_train, y_train, sample_weight=np.ones(y_train.shape))
+    stacker.fit(X_train, y_train, sample_weight=np.ones(y_train.shape))
     y_pred_unit_weight = stacker.predict(X_test)
 
     assert_allclose(y_pred_no_weight, y_pred_unit_weight)
 
-    with ignore_warnings(category=ConvergenceWarning):
-        stacker.fit(X_train, y_train, sample_weight=sample_weight_train)
+    stacker.fit(X_train, y_train, sample_weight=sample_weight_train)
     y_pred_biased = stacker.predict(X_test)
 
     assert np.abs(y_pred_no_weight - y_pred_biased).sum() > 0
@@ -488,7 +485,6 @@ def test_stacking_classifier_sample_weight_fit_param():
     stacker.fit(X_iris, y_iris, sample_weight=np.ones(X_iris.shape[0]))
 
 
-@pytest.mark.filterwarnings("ignore::sklearn.exceptions.ConvergenceWarning")
 @pytest.mark.parametrize(
     "stacker, X, y",
     [


### PR DESCRIPTION
Modify existing pytest that starting failing due to the raised ValueError.

In the pytest X data was scaled so that there was no convergence issues (which would have resulted in the ValueError due to the proposed change for https://github.com/scikit-learn/scikit-learn/issues/27016)